### PR TITLE
Allow to use no-reformat on any container tag

### DIFF
--- a/dist/gutenberg.css
+++ b/dist/gutenberg.css
@@ -654,3 +654,8 @@ a.no-reformat:after {
 abbr[title].no-reformat:after,
 acronym[title].no-reformat:after {
   content: ''; }
+
+.no-reformat abbr:after,
+.no-reformat acronym:after,
+.no-reformat a:after {
+  content: ''; }

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -25,3 +25,13 @@ acronym {
 		}
 	}
 }
+
+.no-reformat {
+	abbr,
+	acronym,
+	a {
+		&:after {
+			content: '';
+		}
+	}
+}


### PR DESCRIPTION
For example:

```html
<body class="no-reformat">
  <a href="#">I will not be formatted</a>
</body>
```
It shouldn't break the old behavior.